### PR TITLE
Limit cardinality of Span Metrics (#545)

### DIFF
--- a/devdocs/pipeline-map.md
+++ b/devdocs/pipeline-map.md
@@ -32,10 +32,14 @@ flowchart TD
         KD:::optional --> NR
         NR(Name resolver):::optional --> AF
         
-        AF(Attributes filter):::optional --> OTELM(OTEL<br/> metrics<br/> exporter):::optional
-        AF --> OTELT(OTEL<br/> traces<br/> exporter):::optional
-        AF --> PROM(Prometheus<br/>HTTP<br/>endpoint):::optional
-        AF --> ALLOY(Alloy<br/>connector):::optional
+        AF(Attributes filter):::optional --> OTELT(OTEL/ALLOY<br/> traces<br/> exporter):::optional
+
+        
+        AF --> IPD(Unknown IP<br/>dropper):::optional
+        IPD --> SNCL(Span Name<br/>cardinality<br/>limiter)
+        SNCL --> OTELRM(OTEL<br/>RED metrics<br/> exporter):::optional
+        SNCL --> OTELSM(OTEL<br/>span/svc graph<br/>metrics<br/> exporter):::optional
+        SNCL --> PROM(Prometheus<br/>HTTP<br/>endpoint):::optional
     end
     CU -.-> |New PIDs| KDB
     KDB(KubeDatabase):::optional <-.- | Aggregated & indexed Pod info | KD

--- a/pkg/app/request/span.go
+++ b/pkg/app/request/span.go
@@ -175,6 +175,10 @@ type Span struct {
 	DBNamespace    string         `json:"-"`
 	SQLCommand     string         `json:"-"`
 	SQLError       *SQLError      `json:"-"`
+
+	// OverrideTraceName is set under some conditions, like spanmetrics reaching the maximum
+	// cardinality for trace names.
+	OverrideTraceName string `json:"-"`
 }
 
 func (s *Span) Inside(parent *Span) bool {
@@ -519,6 +523,9 @@ func (s *Span) ServiceGraphKind() string {
 }
 
 func (s *Span) TraceName() string {
+	if s.OverrideTraceName != "" {
+		return s.OverrideTraceName
+	}
 	switch s.Type {
 	case EventTypeHTTP, EventTypeHTTPClient:
 		name := s.Method
@@ -547,11 +554,11 @@ func (s *Span) TraceName() string {
 		if s.Path == "" {
 			return s.Method
 		}
-		return fmt.Sprintf("%s %s", s.Path, s.Method)
+		return s.Method + " " + s.Path
 	case EventTypeMongoClient:
 		if s.Path != "" && s.Method != "" {
 			// TODO for database operations like listCollections, we need to use s.DbNamespace instead of s.Path
-			return fmt.Sprintf("%s %s", s.Method, s.Path)
+			return s.Method + " " + s.Path
 		}
 		if s.Path != "" {
 			return s.Path

--- a/pkg/components/helpers/cache/expirable_lru.go
+++ b/pkg/components/helpers/cache/expirable_lru.go
@@ -1,0 +1,109 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"container/list"
+	"time"
+)
+
+// ExpirableLRU cache. It is not safe for concurrent access.
+type ExpirableLRU[K comparable, V any] struct {
+	ttl           time.Duration
+	ll            *list.List
+	cache         map[K]*list.Element
+	evictCallBack func(K, V)
+}
+
+type expirableEntry[K comparable, V any] struct {
+	key        K
+	value      V
+	lastAccess time.Time
+}
+
+// ExpirableCacheOpt defines a functional option for configuring an ExpirableLRU cache.
+type ExpirableCacheOpt[K comparable, V any] func(*ExpirableLRU[K, V])
+
+// WithEvictCallBack sets a callback function to be called whenever an entry is evicted
+// from the [ExpirableLRU] cache.
+func WithEvictCallBack[K comparable, V any](cb func(K, V)) ExpirableCacheOpt[K, V] {
+	return func(c *ExpirableLRU[K, V]) {
+		c.evictCallBack = cb
+	}
+}
+
+// NewExpirableLRU creates a new [ExpirableLRU] whose entries older than the provided TTL are removed
+// only when the ExpireAll method is explicitly called.
+func NewExpirableLRU[K comparable, V any](ttl time.Duration, opts ...ExpirableCacheOpt[K, V]) *ExpirableLRU[K, V] {
+	lru := &ExpirableLRU[K, V]{
+		ttl:           ttl,
+		ll:            list.New(),
+		cache:         map[K]*list.Element{},
+		evictCallBack: func(K, V) {},
+	}
+	for _, opt := range opts {
+		opt(lru)
+	}
+	return lru
+}
+
+// Put a value into the cache.
+func (c *ExpirableLRU[K, V]) Put(key K, value V) {
+	timeNow := time.Now()
+	if ee, ok := c.cache[key]; ok {
+		c.ll.MoveToFront(ee)
+		entry := ee.Value.(*expirableEntry[K, V])
+		entry.value = value
+		entry.lastAccess = timeNow
+		return
+	}
+	ele := c.ll.PushFront(&expirableEntry[K, V]{key: key, value: value, lastAccess: timeNow})
+	c.cache[key] = ele
+}
+
+// Get looks up a key's value from the cache.
+func (c *ExpirableLRU[K, V]) Get(key K) (value V, ok bool) {
+	if ele, hit := c.cache[key]; hit {
+		c.ll.MoveToFront(ele)
+		ele.Value.(*expirableEntry[K, V]).lastAccess = time.Now()
+		return ele.Value.(*expirableEntry[K, V]).value, true
+	}
+	return
+}
+
+// Remove the provided key from the cache.
+func (c *ExpirableLRU[K, V]) Remove(key K) {
+	if ele, hit := c.cache[key]; hit {
+		c.removeElement(ele)
+	}
+}
+
+func (c *ExpirableLRU[K, V]) removeElement(e *list.Element) {
+	kv := e.Value.(*expirableEntry[K, V])
+	c.evictCallBack(kv.key, kv.value)
+	c.ll.Remove(e)
+	delete(c.cache, kv.key)
+}
+
+// ExpireAll removes all the entries that are older than the cache TTL.
+// Returns the number of entries removed.
+func (c *ExpirableLRU[K, V]) ExpireAll() int {
+	now := time.Now()
+	removed := 0
+	for older := c.ll.Back(); c.expired(older, now); older = c.ll.Back() {
+		removed++
+		c.removeElement(older)
+	}
+	return removed
+}
+
+func (c *ExpirableLRU[K, V]) expired(elem *list.Element, now time.Time) bool {
+	return elem != nil &&
+		elem.Value.(*expirableEntry[K, V]).lastAccess.Add(c.ttl).Before(now)
+}
+
+// Len returns the number of elements in the cache.
+func (c *ExpirableLRU[K, V]) Len() int {
+	return c.ll.Len()
+}

--- a/pkg/components/helpers/cache/expirable_lru_test.go
+++ b/pkg/components/helpers/cache/expirable_lru_test.go
@@ -1,0 +1,196 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package cache
+
+import (
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExpirableLRU_PutGetRemove(t *testing.T) {
+	lru := NewExpirableLRU[string, string](5 * time.Minute)
+
+	lru.Put("foo", "bar")
+	v, ok := lru.Get("foo")
+	assert.True(t, ok)
+	assert.Equal(t, "bar", v)
+	assert.Equal(t, 1, lru.Len())
+
+	v, ok = lru.Get("baz")
+	assert.False(t, ok)
+	assert.Empty(t, v)
+
+	lru.Put("baz", "bae")
+	v, ok = lru.Get("baz")
+	assert.True(t, ok)
+	assert.Equal(t, "bae", v)
+	assert.Equal(t, 2, lru.Len())
+
+	lru.Remove("foo")
+	_, ok = lru.Get("foo")
+	assert.False(t, ok)
+	assert.Equal(t, 1, lru.Len())
+}
+
+func TestExpirableLRU_ExpireAll(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cache := NewExpirableLRU[string, string](5 * time.Minute)
+
+		// Add items at different times
+		cache.Put("key1", "value1")
+		// Advance time by 2 minutes
+		time.Sleep(2 * time.Minute)
+		cache.Put("key2", "value2")
+		// Advance time by 2 more minutes (key1 is now 4 minutes old, key2 is 2 minutes old)
+		time.Sleep(2 * time.Minute)
+		cache.Put("key3", "value3")
+
+		assert.Zero(t, cache.ExpireAll())
+
+		// All items should be there(none have exceeded 5-minute TTL)
+		assert.Equal(t, 3, cache.Len())
+
+		v, ok := cache.Get("key1")
+		require.True(t, ok, "Expected to find key1")
+		assert.Equal(t, "value1", v)
+		time.Sleep(2 * time.Minute)
+
+		v, ok = cache.Get("key2")
+		require.True(t, ok, "Expected to find key2")
+		assert.Equal(t, "value2", v)
+		time.Sleep(2 * time.Minute)
+
+		v, ok = cache.Get("key3")
+		require.True(t, ok, "Expected to find key3")
+		assert.Equal(t, "value3", v)
+		time.Sleep(2 * time.Minute)
+
+		assert.Equal(t, 1, cache.ExpireAll())
+
+		// key1 is 6 minutes old, should expire while others are still valid
+		assert.Equal(t, 2, cache.Len())
+
+		_, ok = cache.Get("key1")
+		assert.False(t, ok, "Expected key1 to be expired")
+		v, ok = cache.Get("key2")
+		require.True(t, ok, "Expected to find key2")
+		assert.Equal(t, "value2", v)
+		v, ok = cache.Get("key3")
+		require.True(t, ok, "Expected to find key3")
+		assert.Equal(t, "value3", v)
+
+		// Advance age by two minute:
+		//   - "key1": removed (expired)
+		//   - "key2": 6 minutes old
+		//   - "key3": 4 minutes old
+		time.Sleep(2 * time.Minute)
+
+		// add key 4
+		cache.Put("key4", "value4")
+		// Advance age by four minute:
+		//   - "key1": removed (expired)
+		//   - "key2": 10 minutes old
+		//   - "key3": 8 minutes old
+		//   - "key4": 2 minutes old
+		time.Sleep(4 * time.Minute)
+
+		// all the keys but key4 should be expired
+		assert.Equal(t, 2, cache.ExpireAll())
+		assert.Equal(t, 1, cache.Len())
+
+		_, ok = cache.Get("key1")
+		assert.False(t, ok, "Expected key1 to be expired")
+		_, ok = cache.Get("key2")
+		assert.False(t, ok, "Expected key2 to be expired")
+		_, ok = cache.Get("key3")
+		assert.False(t, ok, "Expected key3 to be expired")
+		v, ok = cache.Get("key4")
+		require.True(t, ok, "Expected to find key4")
+		assert.Equal(t, "value4", v)
+
+		// Advance age by four minute:
+		//   - "key1": removed (expired)
+		//   - "key2": removed (expired)
+		//   - "key3": removed (expired)
+		//   - "key4": 6 minutes old
+		time.Sleep(4 * time.Minute)
+
+		// a re-added key should not expire
+		cache.Put("key1", "value1")
+		// Advance age by two minute:
+		//   - "key1": two minutes old
+		//   - "key2": removed (expired)
+		//   - "key3": removed (expired)
+		//   - "key4": 10 minutes old
+		time.Sleep(2 * time.Minute)
+
+		assert.Equal(t, 1, cache.ExpireAll())
+
+		assert.Equal(t, 1, cache.Len())
+		v, ok = cache.Get("key1")
+		require.True(t, ok, "Expected to find key1")
+		assert.Equal(t, "value1", v)
+		_, ok = cache.Get("key2")
+		assert.False(t, ok, "Expected key2 to be expired")
+		_, ok = cache.Get("key3")
+		assert.False(t, ok, "expected key 3 to be expired")
+		_, ok = cache.Get("key4")
+		assert.False(t, ok, "expected key 4 to be expired")
+	})
+}
+
+func TestWithEvictCallBack(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		var evictedKeys []int
+		var evictedVals []string
+		cache := NewExpirableLRU[int, string](5*time.Minute,
+			WithEvictCallBack(func(k int, v string) {
+				evictedKeys = append(evictedKeys, k)
+				evictedVals = append(evictedVals, v)
+			}))
+
+		cache.Put(1, "one")
+		time.Sleep(1 * time.Minute)
+		cache.Put(2, "two")
+		time.Sleep(2 * time.Minute)
+		cache.Put(3, "three")
+
+		assert.Zero(t, cache.ExpireAll())
+		assert.Empty(t, evictedKeys)
+		assert.Empty(t, evictedVals)
+
+		time.Sleep(4 * time.Minute)
+
+		assert.Equal(t, 2, cache.ExpireAll())
+		assert.Equal(t, []int{1, 2}, evictedKeys)
+		assert.Equal(t, []string{"one", "two"}, evictedVals)
+	})
+}
+
+func TestPutAlsoUpdatesTTL(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		cache := NewExpirableLRU[int, string](5 * time.Minute)
+		cache.Put(1, "one")
+
+		time.Sleep(3 * time.Minute)
+		cache.Put(2, "two")
+
+		assert.Zero(t, cache.ExpireAll())
+
+		time.Sleep(3 * time.Minute)
+		cache.Put(1, "another")
+		time.Sleep(3 * time.Minute)
+
+		assert.Equal(t, 1, cache.ExpireAll())
+		assert.Equal(t, 1, cache.Len())
+		_, ok := cache.Get(1)
+		assert.True(t, ok, "Expected to find key1")
+		_, ok = cache.Get(2)
+		assert.False(t, ok, "Expected key2 to be expired")
+	})
+}

--- a/pkg/components/svc/svc.go
+++ b/pkg/components/svc/svc.go
@@ -65,6 +65,10 @@ type ServiceNameNamespace struct {
 	Namespace string
 }
 
+func (sn ServiceNameNamespace) String() string {
+	return sn.Namespace + "/" + sn.Name
+}
+
 // UID uniquely identifies a service instance across the whole system
 // according to the OpenTelemetry specification: (name, namespace, instance)
 type UID struct {

--- a/pkg/export/otel/otelcfg/config_metrics.go
+++ b/pkg/export/otel/otelcfg/config_metrics.go
@@ -42,7 +42,8 @@ type MetricsConfig struct {
 	// and the Info messages leak internal details that are not usually valuable for the final user.
 	SDKLogLevel string `yaml:"otel_sdk_log_level" env:"OTEL_EBPF_SDK_LOG_LEVEL"`
 
-	// Features of metrics that are can be exported. Accepted values are "application" and "network".
+	// Features of metrics that are can be exported. Accepted values: application, network, application_process,
+	// application_span, application_service_graph, ...
 	// envDefault is provided to avoid breaking changes
 	Features []string `yaml:"features" env:"OTEL_EBPF_METRICS_FEATURES,expand" envDefault:"${OTEL_EBPF_METRIC_FEATURES}"  envSeparator:","`
 

--- a/pkg/obi/config.go
+++ b/pkg/obi/config.go
@@ -142,7 +142,8 @@ var DefaultConfig = Config{
 		HostID: HostIDConfig{
 			FetchTimeout: 500 * time.Millisecond,
 		},
-		DropMetricsUnresolvedIPs: true,
+		DropMetricsUnresolvedIPs:       true,
+		MetricSpanNameAggregationLimit: 100,
 	},
 	Routes: &transform.RoutesConfig{
 		Unmatch:      transform.UnmatchDefault,
@@ -256,8 +257,14 @@ type Attributes struct {
 	Select               attributes.Selection          `yaml:"select"`
 	HostID               HostIDConfig                  `yaml:"host_id"`
 	ExtraGroupAttributes map[string][]attr.Name        `yaml:"extra_group_attributes"`
+
 	// DropMetricsUnresolvedIPs drops metrics that contain unresolved IP addresses to reduce cardinality
 	DropMetricsUnresolvedIPs bool `yaml:"drop_metric_unresolved_ips" env:"OTEL_EBPF_DROP_METRIC_UNRESOLVED_IPS"`
+
+	// MetricSpanNameAggregationLimit works PER SERVICE and only relates to span_metrics.
+	// When the span_name cardinality surpasses this limit, the span_name will be reported as AGGREGATED.
+	// If the value <= 0, it is disabled.
+	MetricSpanNameAggregationLimit int `yaml:"metric_span_names_limit" env:"OTEL_EBPF_METRIC_SPAN_NAMES_LIMIT"`
 }
 
 type HostIDConfig struct {

--- a/pkg/obi/config_test.go
+++ b/pkg/obi/config_test.go
@@ -214,6 +214,7 @@ discovery:
 			ExtraGroupAttributes: map[string][]attr.Name{
 				"k8s_app_meta": {"k8s.app.version"},
 			},
+			MetricSpanNameAggregationLimit: 100,
 		},
 		Routes: &transform.RoutesConfig{
 			Unmatch:      transform.UnmatchHeuristic,

--- a/pkg/pipe/msg/queue_test.go
+++ b/pkg/pipe/msg/queue_test.go
@@ -87,6 +87,22 @@ func TestChainedBypass(t *testing.T) {
 	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
 }
 
+func TestOneToManyBypass(t *testing.T) {
+	src := NewQueue[int]()
+	dst := NewQueue[int]()
+	src.Bypass(dst)
+	ch1 := dst.Subscribe()
+	ch2 := dst.Subscribe()
+	ch3 := dst.Subscribe()
+	go src.Send(123)
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch1, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch2, timeout))
+	assert.Equal(t, 123, testutil.ReadChannel(t, ch3, timeout))
+	testutil.ChannelEmpty(t, ch1, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch2, 5*time.Millisecond)
+	testutil.ChannelEmpty(t, ch3, 5*time.Millisecond)
+}
+
 func TestErrors(t *testing.T) {
 	t.Run("can't bypass to itself", func(t *testing.T) {
 		q := NewQueue[int]()

--- a/pkg/transform/ips_filter.go
+++ b/pkg/transform/ips_filter.go
@@ -22,14 +22,10 @@ func IPsFilter(dropUnresolvedIPs bool, input, output *msg.Queue[[]request.Span])
 		return func(_ context.Context) {
 			defer output.Close()
 			for spans := range in {
-				copiedSpans := make([]request.Span, len(spans))
-				copy(copiedSpans, spans)
-
-				for i := range copiedSpans {
-					span := &copiedSpans[i]
-					filterIPsFromSpan(span)
+				for i := range spans {
+					filterIPsFromSpan(&spans[i])
 				}
-				output.Send(copiedSpans)
+				output.Send(spans)
 			}
 		}, nil
 	}

--- a/pkg/transform/span_name_limiter.go
+++ b/pkg/transform/span_name_limiter.go
@@ -1,0 +1,123 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package transform
+
+import (
+	"context"
+	"log/slog"
+	"slices"
+	"time"
+
+	"go.opentelemetry.io/obi/pkg/app/request"
+	"go.opentelemetry.io/obi/pkg/components/helpers/cache"
+	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/prom"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+	"go.opentelemetry.io/obi/pkg/pipe/swarm"
+)
+
+const aggregatedMark = "AGGREGATED"
+
+type spanNameLimiter struct {
+	limit int
+	log   *slog.Logger
+	in    <-chan []request.Span
+	out   *msg.Queue[[]request.Span]
+
+	spanNamesCount *cache.ExpirableLRU[svc.ServiceNameNamespace, *routesCount]
+	ttl            time.Duration
+}
+
+type routesCount struct {
+	routes map[string]struct{}
+	// to save memory: when routes length reaches the per-service limit,
+	// we can set it to nil to save memory and use this flag instead
+	limitReached bool
+}
+
+type SpanNameLimiterConfig struct {
+	Limit int
+	OTEL  *otelcfg.MetricsConfig
+	Prom  *prom.PrometheusConfig
+}
+
+// SpanNameLimiter applies only to metrics. If span metrics are enabled and
+// metric_span_names_limit > 0, it renames all the span.name attributes when the cardinality of that attribute
+// for a given, alive service exceeds max_span_names.
+func SpanNameLimiter(cfg SpanNameLimiterConfig, input, output *msg.Queue[[]request.Span]) swarm.InstanceFunc {
+	return func(_ context.Context) (swarm.RunFunc, error) {
+		if !enabled(&cfg) {
+			return swarm.Bypass(input, output)
+		}
+		log := slog.With("component", "SpanNameLimiter")
+		ttl := max(cfg.OTEL.TTL, cfg.Prom.TTL)
+		return (&spanNameLimiter{
+			limit: cfg.Limit,
+			log:   log,
+			in:    input.Subscribe(),
+			out:   output,
+			ttl:   ttl,
+			spanNamesCount: cache.NewExpirableLRU[svc.ServiceNameNamespace, *routesCount](ttl,
+				cache.WithEvictCallBack(func(key svc.ServiceNameNamespace, _ *routesCount) {
+					log.Debug("evicting inactive service", "key", key)
+				})),
+		}).doLimit, nil
+	}
+}
+
+func enabled(cfg *SpanNameLimiterConfig) bool {
+	return cfg.Limit > 0 &&
+		(slices.Contains(cfg.OTEL.Features, otelcfg.FeatureSpan) ||
+			slices.Contains(cfg.Prom.Features, otelcfg.FeatureSpan))
+}
+
+func (l *spanNameLimiter) doLimit(ctx context.Context) {
+	defer l.out.Close()
+	l.log.Debug("Starting", "ttl", l.ttl, "limit", l.limit)
+	expirer := time.NewTicker(l.ttl)
+	for {
+		select {
+		case <-ctx.Done():
+			l.log.Debug("context done. Stopping")
+			return
+		case <-expirer.C:
+			removed := l.spanNamesCount.ExpireAll()
+			l.log.Debug("inactive services expired", "len", removed)
+		case spans := <-l.in:
+			l.aggregate(spans)
+			l.out.Send(spans)
+		}
+	}
+}
+
+func (l *spanNameLimiter) aggregate(spans []request.Span) {
+	// assuming many spans from the same service could come in a row
+	// we can slightly optimize by avoiding the cache lookup for each span
+	var lastKey svc.ServiceNameNamespace
+	lastCount := &routesCount{}
+
+	for i := range spans {
+		span := &spans[i]
+		if key := span.Service.UID.NameNamespace(); key != lastKey {
+			lastKey = key
+			count, ok := l.spanNamesCount.Get(key)
+			if !ok {
+				count = &routesCount{routes: map[string]struct{}{}}
+				l.spanNamesCount.Put(key, count)
+			}
+			lastCount = count
+		}
+		if lastCount.limitReached {
+			span.OverrideTraceName = aggregatedMark
+			continue
+		}
+		lastCount.routes[span.TraceName()] = struct{}{}
+		if len(lastCount.routes) >= l.limit {
+			// free some memory and set the flag
+			lastCount.routes = nil
+			lastCount.limitReached = true
+		}
+	}
+}

--- a/pkg/transform/span_name_limiter_test.go
+++ b/pkg/transform/span_name_limiter_test.go
@@ -1,0 +1,171 @@
+// Copyright The OpenTelemetry Authors
+// SPDX-License-Identifier: Apache-2.0
+
+package transform
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"testing"
+	"testing/synctest"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"go.opentelemetry.io/obi/pkg/app/request"
+	"go.opentelemetry.io/obi/pkg/components/svc"
+	"go.opentelemetry.io/obi/pkg/components/testutil"
+	"go.opentelemetry.io/obi/pkg/export/otel/otelcfg"
+	"go.opentelemetry.io/obi/pkg/export/prom"
+	"go.opentelemetry.io/obi/pkg/pipe/msg"
+)
+
+const maxCardinalityBeforeAggregation = 10
+
+func TestSpanNameLimiter(t *testing.T) {
+	// GIVEN a SpanNameLimiter instance
+	input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+	outCh := output.Subscribe()
+	runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
+		Limit: maxCardinalityBeforeAggregation,
+		OTEL:  &otelcfg.MetricsConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+		Prom:  &prom.PrometheusConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+	}, input, output)(t.Context())
+	require.NoError(t, err)
+
+	go runSpanNameLimiter(t.Context())
+
+	// will check that different instances of the same service will be aggregated together
+	svc1i1 := svc.Attrs{UID: svc.UID{Namespace: "ns", Name: "svc1", Instance: "i1"}}
+	svc1i2 := svc.Attrs{UID: svc.UID{Namespace: "ns", Name: "svc1", Instance: "i2"}}
+	svc2 := svc.Attrs{UID: svc.UID{Namespace: "ns", Name: "svc2", Instance: "i"}}
+
+	t.Run("do not aggregate if cardinality is low", func(t *testing.T) {
+		input.Send([]request.Span{
+			{Service: svc1i1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-1"},
+			{Service: svc1i1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-2"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-3"},
+		})
+		input.Send([]request.Span{
+			{Service: svc1i1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-4"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-5"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-6"},
+			{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: "/bar"},
+		})
+
+		spans := testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 3)
+		assert.Equal(t, "GET /foo-1", spans[0].TraceName())
+		assert.Equal(t, "GET /foo-2", spans[1].TraceName())
+		assert.Equal(t, "GET /foo-3", spans[2].TraceName())
+		spans = testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 4)
+		assert.Equal(t, "GET /foo-4", spans[0].TraceName())
+		assert.Equal(t, "GET /foo-5", spans[1].TraceName())
+		assert.Equal(t, "GET /foo-6", spans[2].TraceName())
+		assert.Equal(t, "GET /bar", spans[3].TraceName())
+	})
+
+	t.Run("start aggregating if max cardinality is reached", func(t *testing.T) {
+		input.Send([]request.Span{
+			{Service: svc1i1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-7"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-8"},
+			{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: "/bar-2"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-9"},
+		})
+		input.Send([]request.Span{
+			{Service: svc1i1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-10"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-11"},
+			{Service: svc1i2, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo-12"},
+			{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: "/bar-6"},
+		})
+		spans := testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 4)
+		assert.Equal(t, "GET /foo-7", spans[0].TraceName())
+		assert.Equal(t, "GET /foo-8", spans[1].TraceName())
+		assert.Equal(t, "GET /bar-2", spans[2].TraceName())
+		spans = testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 4)
+		assert.Equal(t, "GET /foo-10", spans[0].TraceName())
+		assert.Equal(t, "AGGREGATED", spans[1].TraceName())
+		assert.Equal(t, "AGGREGATED", spans[2].TraceName())
+		assert.Equal(t, "GET /bar-6", spans[3].TraceName())
+	})
+
+	t.Run("do not aggregate when same route is provided many times", func(t *testing.T) {
+		for i := 0; i < 20; i++ {
+			input.Send([]request.Span{
+				{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: "/bar"},
+			})
+			spans := testutil.ReadChannel(t, outCh, testTimeout)
+			require.Len(t, spans, 1)
+			assert.Equal(t, "GET /bar", spans[0].TraceName())
+		}
+	})
+}
+
+func TestSpanNameLimiter_ExpireOld(t *testing.T) {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	synctest.Test(t, func(t *testing.T) {
+		// GIVEN a SpanNameLimiter instance
+		input := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+		output := msg.NewQueue[[]request.Span](msg.ChannelBufferLen(10))
+		outCh := output.Subscribe()
+		runSpanNameLimiter, err := SpanNameLimiter(SpanNameLimiterConfig{
+			Limit: maxCardinalityBeforeAggregation,
+			OTEL:  &otelcfg.MetricsConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+			Prom:  &prom.PrometheusConfig{Features: []string{otelcfg.FeatureSpan}, TTL: time.Minute},
+		}, input, output)(t.Context())
+		require.NoError(t, err)
+
+		go runSpanNameLimiter(t.Context())
+
+		svc1 := svc.Attrs{UID: svc.UID{Namespace: "ns", Name: "svc1", Instance: "i1"}}
+		svc2 := svc.Attrs{UID: svc.UID{Namespace: "ns", Name: "svc2", Instance: "i2"}}
+
+		for i := 0; i < maxCardinalityBeforeAggregation+1; i++ {
+			input.Send([]request.Span{
+				{Service: svc1, Type: request.EventTypeHTTP, Method: "GET", Route: fmt.Sprintf("/foo-%d", i)},
+				{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: fmt.Sprintf("/bar-%d", i)},
+			})
+		}
+		// before max cardinality, nothing is aggregated
+		for i := 0; i < maxCardinalityBeforeAggregation; i++ {
+			spans := testutil.ReadChannel(t, outCh, testTimeout)
+			require.Len(t, spans, 2)
+			assert.Equal(t, fmt.Sprintf("GET /foo-%d", i), spans[0].TraceName())
+			assert.Equal(t, fmt.Sprintf("GET /bar-%d", i), spans[1].TraceName())
+		}
+		// after max cardinality, it starts aggregating
+		spans := testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 2)
+		assert.Equal(t, "AGGREGATED", spans[0].TraceName())
+		assert.Equal(t, "AGGREGATED", spans[1].TraceName())
+
+		// During TTL time, a service stops sending data while the other keeps going
+		for i := 0; i < 13; i++ {
+			// will expect that te internal expiration timer is eventually triggered during this loop
+			time.Sleep(10 * time.Second)
+			input.Send([]request.Span{
+				{Service: svc1, Type: request.EventTypeHTTP, Method: "GET", Route: "/foo"},
+			})
+			spans = testutil.ReadChannel(t, outCh, testTimeout)
+			require.Len(t, spans, 1)
+			assert.Equal(t, "AGGREGATED", spans[0].TraceName())
+		}
+
+		// Then if the service comes back after the TTL, it does not aggregate again
+		// until the max cardinality is reached
+		input.Send([]request.Span{
+			{Service: svc1, Type: request.EventTypeHTTP, Method: "GET", Route: "/still-there"},
+			{Service: svc2, Type: request.EventTypeHTTP, Method: "GET", Route: "/back-again"},
+		})
+		spans = testutil.ReadChannel(t, outCh, testTimeout)
+		require.Len(t, spans, 2)
+		assert.Equal(t, "AGGREGATED", spans[0].TraceName())
+		assert.Equal(t, "GET /back-again", spans[1].TraceName())
+	})
+}


### PR DESCRIPTION
* first untested implementation of spannamelimiter

* add testable LRU cache

* expirable LRU: extra tests + eviction callback

* unit tested implementation

* some improvements in thelimiter. pipe tests not yet working

* Fixed pipeline and some changes ready for review

* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru_test.go



* Update pkg/components/helpers/cache/expirable_lru.go



* Update pkg/components/helpers/cache/expirable_lru.go



* Update pkg/app/request/span.go



* Update pkg/components/helpers/cache/expirable_lru.go



* fix linter complaint

* Fix pipeline

---------